### PR TITLE
fix: stop treating warnings as errors

### DIFF
--- a/.github/workflows/CI-Node.js.yml
+++ b/.github/workflows/CI-Node.js.yml
@@ -31,5 +31,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm run build --if-present
+    - run: CI=false npm run build--if-present
     - run: npm test


### PR DESCRIPTION
Stop treating warnings as errors